### PR TITLE
Fix deprecation warning when leaving reviews

### DIFF
--- a/src/gerrit_ssh_command.rs
+++ b/src/gerrit_ssh_command.rs
@@ -26,6 +26,7 @@ impl GerritSshCommand {
         let patchset_number = patchset.number;
         let mut command = self.config.gerrit.ssh.command();
         command.args(["gerrit", "review"]);
+        command.args(["--project", &format!("\"{}\"", change.project)]);
         command.args(["--message", &format!("\"{}\"", &review.message)]);
         if let Some(verified) = &review.verified {
             let label = "Verified";


### PR DESCRIPTION
Using the SSH command `gerrit review` without providing `--project` emits a deprecation warning. Add the argument, which was already plumbed to the function.